### PR TITLE
Change "writing your first bot" title

### DIFF
--- a/docs/docs/bots/scheduledPostBot.md
+++ b/docs/docs/bots/scheduledPostBot.md
@@ -1,4 +1,4 @@
-﻿# Writing your first bot
+﻿# Writing your first scheduled bot
 
 Bots are accounts on the network that post automatically. Popular ones include bots that post the magnitude of recent earthquakes, traffic alerts, etc.
 


### PR DESCRIPTION
Change "Writing your first bot" to "Writing your first scheduled bot" to distinguish between simple posting bots and scheduled posting bots. It makes the documentation a little easier to move through. I was looking for the scheduled bot documentation and initially dismissed it thinking it was the same as https://bluesky.idunno.dev/docs/posting.html