### PR TITLE
Fix identity store resolution, refresh waits and AddBluesky overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,38 @@
   credential persistence completes before the updated credentials are used, and any exceptions it throws surface to the caller rather than being
   silently swallowed. Code which persists credentials should move from the `CredentialsUpdated` event to `CredentialsUpdatedAsync`.
 
+#### idunno.Bluesky.AspNet.Authentication
+
+* Added `AddBlueskyAgentFactory(string authenticationScheme)`, and a matching `BlueskyAgentFactory` constructor overload, for applications which registered
+  Bluesky authentication under a scheme name other than `BlueskyAuthenticationDefaults.AuthenticationScheme`. The factory takes the scheme from the current
+  user when the request has one, so this only affects agents created for anonymous requests.
+
 ### Changed
 
 #### idunno.Bluesky
 
 * `DefaultFacetExtractor` now uses a more permissive regex for URLs, which allows for query strings to be included in the extracted URL.
+
+### Fixed
+
+#### idunno.Bluesky.AspNet.Authentication
+
+* A custom `IIdentityStore` configured in `AddBluesky(...)` is now actually used. `BlueskyAuthenticationOptions` are configured against the name of the
+  authentication scheme they belong to, but `BlueskyAuthenticationHandler`, `BlueskyAgentFactory` and `ProfileClaimsTransformer` all read the store from
+  the monitor's unnamed `CurrentValue` instance, which the application's configuration delegate never runs against. Post configuration then filled the
+  missing store in with an `EphemeralIdentityStore`, so an application which configured a `DistributedCacheIdentityStore` silently ran on in-process
+  memory instead, losing every signed in user when the process recycled and failing to share credentials between instances of a multi instance
+  deployment. All three now resolve the store for the scheme they are running as.
+* Requests which arrive whilst another request is refreshing the current user's credentials no longer fail authentication when the refresh completes
+  before the waiting request starts polling for it. Previously the wait loop only checked the identity store after sleeping, so a refresh which
+  finished in the window between the initial check and the loop starting left the waiting request to fall through to a failed authentication result,
+  even though freshly refreshed credentials were sitting in the identity store. The loop now checks the store before waiting, and a request whose
+  wait is aborted returns a cancellation result rather than throwing a `TaskCanceledException`.
+* `ProfileClaimsTransformer` now saves any credentials updated whilst it retrieves the user's profile to the configured `IIdentityStore`. Previously the
+  agent it created had no credential update callback, so a DPoP nonce rotation triggered by the profile lookup was discarded, forcing another nonce
+  rotation round trip on the next call.
+* `AuthenticationBuilder.AddBluesky()` and `AuthenticationBuilder.AddBluesky(string authenticationScheme)` no longer throw an `ArgumentNullException`.
+  Both overloads pass a `null` configuration delegate to the underlying overload, which rejected it, so neither could be used.
 
 ### Breaking Changes
 
@@ -31,6 +58,9 @@
 
 #### idunno.Bluesky.AspNet.Authentication
 
+* `ProfileClaimsTransformer`'s constructor takes an additional `IOptionsMonitor<BlueskyAuthenticationOptions>` parameter, used to locate the
+  `IIdentityStore` updated credentials are saved to. The transformer is resolved from dependency injection, so applications registering it with
+  `AddProfileClaimsTransformer()` need no changes.
 * `IIdentityStore.OnCredentialsUpdated` has changed from `void OnCredentialsUpdated(object? sender, CredentialsUpdatedEventArgs e)` to
   `Task OnCredentialsUpdated(CredentialsUpdatedEventArgs e, CancellationToken cancellationToken = default)`, and is now hooked up to the agent's
   `CredentialsUpdatedAsync` callback rather than its `CredentialsUpdated` event. The previous implementation discarded the task returned by the

--- a/src/idunno.Bluesky.AspNet.Authentication/BlueskyAgentFactory.cs
+++ b/src/idunno.Bluesky.AspNet.Authentication/BlueskyAgentFactory.cs
@@ -17,9 +17,12 @@ namespace idunno.Bluesky.AspNet.Authentication;
 public sealed class BlueskyAgentFactory
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IOptionsMonitor<BlueskyAuthenticationOptions> _authenticationOptionsMonitor;
+    private readonly string _authenticationScheme;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="BlueskyAgentFactory"/> class.
+    /// Creates a new instance of the <see cref="BlueskyAgentFactory"/> class, for the authentication scheme specified by
+    /// <see cref="BlueskyAuthenticationDefaults.AuthenticationScheme"/>.
     /// </summary>
     /// <param name="contextAccessor">The <see cref="IHttpContextAccessor"/></param>
     /// <param name="authenticationOptionsMonitor">The <see cref="IOptionsMonitor{BlueskyAuthenticationOptions}"/></param>
@@ -30,29 +33,66 @@ public sealed class BlueskyAgentFactory
         IHttpContextAccessor contextAccessor,
         IOptionsMonitor<BlueskyAuthenticationOptions> authenticationOptionsMonitor,
         IOptionsMonitor<BlueskyAgentOptions> agentOptionsMonitor,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory) :
+            this(contextAccessor, authenticationOptionsMonitor, agentOptionsMonitor, loggerFactory, BlueskyAuthenticationDefaults.AuthenticationScheme)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="BlueskyAgentFactory"/> class for the specified authentication scheme.
+    /// </summary>
+    /// <param name="contextAccessor">The <see cref="IHttpContextAccessor"/></param>
+    /// <param name="authenticationOptionsMonitor">The <see cref="IOptionsMonitor{BlueskyAuthenticationOptions}"/></param>
+    /// <param name="agentOptionsMonitor">The <see cref="IOptionsMonitor{BlueskyAgentOptions}"/></param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/></param>
+    /// <param name="authenticationScheme">
+    ///   The name of the authentication scheme whose <see cref="BlueskyAuthenticationOptions"/> the factory should use when the current request has no
+    ///   authenticated Bluesky user to take the scheme name from.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown if any of the parameters are <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="authenticationScheme"/> is empty or white space.</exception>
+    public BlueskyAgentFactory(
+        IHttpContextAccessor contextAccessor,
+        IOptionsMonitor<BlueskyAuthenticationOptions> authenticationOptionsMonitor,
+        IOptionsMonitor<BlueskyAgentOptions> agentOptionsMonitor,
+        ILoggerFactory loggerFactory,
+        string authenticationScheme)
     {
         ArgumentNullException.ThrowIfNull(contextAccessor);
         ArgumentNullException.ThrowIfNull(authenticationOptionsMonitor);
-        ArgumentNullException.ThrowIfNull(authenticationOptionsMonitor.CurrentValue.IdentityStore);
         ArgumentNullException.ThrowIfNull(agentOptionsMonitor);
         ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(authenticationScheme);
 
-        IdentityStore = authenticationOptionsMonitor.CurrentValue.IdentityStore;
-        AuthenticationOptions = authenticationOptionsMonitor.CurrentValue;
         BlueskyAgentOptions = agentOptionsMonitor.CurrentValue;
         BlueskyAgentOptions.LoggerFactory = loggerFactory;
 
+        _authenticationOptionsMonitor = authenticationOptionsMonitor;
+        _authenticationScheme = authenticationScheme;
         _httpContextAccessor = contextAccessor;
     }
-
-    internal BlueskyAuthenticationOptions AuthenticationOptions { get; }
 
     internal BlueskyAgentOptions BlueskyAgentOptions { get; }
 
     internal HttpContext? Context => _httpContextAccessor.HttpContext;
 
-    internal IIdentityStore IdentityStore { get; }
+    /// <summary>
+    /// Gets the <see cref="BlueskyAuthenticationOptions"/> configured for the specified authentication scheme.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///   <see cref="BlueskyAuthenticationOptions"/> are configured against the name of the authentication scheme they belong to, so the unnamed options
+    ///   instance exposed by <see cref="IOptionsMonitor{TOptions}.CurrentValue"/> is not the instance the authentication handler is using, and would not
+    ///   carry any configuration the application applied in its call to <c>AddBluesky</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="authenticationScheme">The name of the authentication scheme to get the options for, if known.</param>
+    internal BlueskyAuthenticationOptions GetAuthenticationOptions(string? authenticationScheme)
+    {
+        authenticationScheme = string.IsNullOrEmpty(authenticationScheme) ? _authenticationScheme : authenticationScheme;
+
+        return _authenticationOptionsMonitor.Get(authenticationScheme);
+    }
 
     /// <summary>
     /// Creates a <see cref="BlueskyAgent"/>.
@@ -78,10 +118,18 @@ public sealed class BlueskyAgentFactory
         }
         else
         {
+            identity = null;
             agent = new BlueskyAgent(options: BlueskyAgentOptions);
         }
 
-        agent.CredentialsUpdatedAsync = IdentityStore.OnCredentialsUpdated;
+        // An identity issued by the authentication handler carries the name of the scheme which issued it as its authentication type,
+        // which is the name the options for that scheme, and so its identity store, are configured against.
+        IIdentityStore? identityStore = GetAuthenticationOptions(identity?.AuthenticationType).IdentityStore;
+
+        if (identityStore is not null)
+        {
+            agent.CredentialsUpdatedAsync = identityStore.OnCredentialsUpdated;
+        }
 
         return agent;
     }

--- a/src/idunno.Bluesky.AspNet.Authentication/BlueskyAuthenticationHandler.cs
+++ b/src/idunno.Bluesky.AspNet.Authentication/BlueskyAuthenticationHandler.cs
@@ -29,8 +29,6 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
 
     private static readonly TimeSpan s_refreshClockSkew = TimeSpan.FromMinutes(5);
 
-    private readonly IIdentityStore _identityStore;
-
     private Task<AuthenticateResult>? _readCookieTask;
 
     private DateTimeOffset? _refreshIssuedUtc;
@@ -48,7 +46,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
     /// <param name="logger">The <see cref="ILoggerFactory"/> to create loggers from.</param>
     /// <param name="encoder">The <see cref="UrlEncoder"/>.</param>
     /// <param name="clock">The <see cref="ISystemClock"/>.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> or <paramref name="options.CurrentValue.IdentityStore"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is <see langword="null"/>.</exception>
     [Obsolete("ISystemClock is obsolete, use TimeProvider on AuthenticationSchemeOptions instead.")]
     [SuppressMessage("Info Code Smell", "S1133:Deprecated code should be removed", Justification = "Until ASP.NET Core removes this from SignInAuthenticationHandler it must stay.")]
     public BlueskyAuthenticationHandler(
@@ -59,9 +57,6 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
         ISystemClock clock) : base(options, logger, encoder, clock)
     {
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(options.CurrentValue.IdentityStore);
-
-        _identityStore = options.CurrentValue.IdentityStore;
 
         BlueskyAgentOptionsMonitor = agentOptions;
     }
@@ -73,7 +68,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
     /// <param name="agentOptions">The monitor for the agent options instance.</param>
     /// <param name="logger">The <see cref="ILoggerFactory"/> to create loggers from.</param>
     /// <param name="encoder">The <see cref="UrlEncoder"/>.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> or <paramref name="options.CurrentValue.IdentityStore"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is <see langword="null"/>.</exception>
     public BlueskyAuthenticationHandler(
         IOptionsMonitor<BlueskyAuthenticationOptions> options,
         IOptionsMonitor<BlueskyAgentOptions> agentOptions,
@@ -82,12 +77,24 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
         : base(options, logger, encoder)
     {
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(options.CurrentValue.IdentityStore);
-
-        _identityStore = options.CurrentValue.IdentityStore;
 
         BlueskyAgentOptionsMonitor = agentOptions;
     }
+
+    /// <summary>
+    /// Gets the <see cref="IIdentityStore"/> configured for the authentication scheme this handler is running as.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///   <see cref="BlueskyAuthenticationOptions"/> are configured against the name of the authentication scheme they belong to, so this must come from
+    ///   <see cref="AuthenticationHandler{TOptions}.Options"/>, which the base class resolves with the scheme name, rather than from the unnamed options
+    ///   instance exposed by <see cref="IOptionsMonitor{TOptions}.CurrentValue"/>.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown if no <see cref="IIdentityStore"/> is configured for the scheme.</exception>
+    private IIdentityStore IdentityStore =>
+        Options.IdentityStore ??
+            throw new InvalidOperationException($"No {nameof(IIdentityStore)} is configured for the {Scheme.Name} authentication scheme.");
 
     /// <summary>
     /// The handler calls methods on the events which give the application control at certain points where processing is occurring.
@@ -227,7 +234,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
         }
 
         // Store the full identity in the identity store.
-        await _identityStore.Add(userIdentity).ConfigureAwait(false);
+        await IdentityStore.Add(userIdentity).ConfigureAwait(false);
 
         // Strip the principal down to just the DID, acting as a reference cookie.
         var ticketPrincipal = new ClaimsPrincipal(
@@ -277,7 +284,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
 
         if (CurrentUserDid is not null)
         {
-            await _identityStore.Remove(CurrentUserDid).ConfigureAwait(false);
+            await IdentityStore.Remove(CurrentUserDid).ConfigureAwait(false);
         }
 
         var context = new BlueskySigningOutContext(
@@ -479,7 +486,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
         }
 
         CurrentUserDid = new Did(didClaim.Value);
-        ClaimsIdentity? storedIdentity = await _identityStore.GetIdentity(didClaim.Value).ConfigureAwait(false);
+        ClaimsIdentity? storedIdentity = await IdentityStore.GetIdentity(didClaim.Value).ConfigureAwait(false);
 
         if (storedIdentity == null)
         {
@@ -491,7 +498,7 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
 
         if (expiresUtc != null && expiresUtc.Value < currentUtc)
         {
-            await _identityStore.Remove(CurrentUserDid).ConfigureAwait(false);
+            await IdentityStore.Remove(CurrentUserDid).ConfigureAwait(false);
             CurrentUserDid = null;
             return AuthenticateResults.s_expiredTicket;
         }
@@ -511,9 +518,9 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
                     return AuthenticateResults.s_cancellationRequested;
                 }
 
-                if (!await _identityStore.IsRefreshing(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false))
+                if (!await IdentityStore.IsRefreshing(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false))
                 {
-                    bool startedRefresh = await _identityStore.StartRefresh(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                    bool startedRefresh = await IdentityStore.StartRefresh(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
                     if (startedRefresh)
                     {
@@ -525,15 +532,15 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
                             if (!refreshCredentialsResult || !agent.IsAuthenticated)
                             {
                                 CurrentUserDid = null;
-                                await _identityStore.Remove(refreshingFor).ConfigureAwait(false);
+                                await IdentityStore.Remove(refreshingFor).ConfigureAwait(false);
                                 return AuthenticateResults.s_tokenRefreshFailed;
                             }
                             else
                             {
-                                await _identityStore.Update(agent.Credentials, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                                await IdentityStore.Update(agent.Credentials, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
                                 // Update the ticket with the new credentials
-                                ClaimsIdentity? updatedIdentity = await _identityStore.GetIdentity(refreshingFor).ConfigureAwait(false);
+                                ClaimsIdentity? updatedIdentity = await IdentityStore.GetIdentity(refreshingFor).ConfigureAwait(false);
                                 if (updatedIdentity == null)
                                 {
                                     return AuthenticateResults.s_identityStoreRefreshMissing;
@@ -550,39 +557,47 @@ public class BlueskyAuthenticationHandler : SignInAuthenticationHandler<BlueskyA
                         }
                         finally
                         {
-                            await _identityStore.EndRefresh(refreshingFor, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                            await IdentityStore.EndRefresh(refreshingFor, cancellationToken: CancellationToken.None).ConfigureAwait(false);
                         }
                     }
 
                     // If we get here, then another request has already started a refresh, so we will wait for it to complete below.
                 }
 
-                // A refresh is in progress, so wait for it to complete.
-                int refreshCheckCount = 0;
-                while (!Context.RequestAborted.IsCancellationRequested &&
-                    refreshCheckCount < Options.MaxRefreshChecks &&
-                    await _identityStore.IsRefreshing(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false))
+                // A refresh is in progress, so wait for it to complete, then use the credentials it stored.
+                //
+                // The refresh may also have completed in the window between the check above and here, so check the
+                // store before waiting, otherwise a request which arrives just as a refresh finishes would be
+                // failed even though valid credentials are sitting in the store.
+                for (int refreshCheckCount = 0; refreshCheckCount < Options.MaxRefreshChecks; refreshCheckCount++)
                 {
                     if (Context.RequestAborted.IsCancellationRequested)
                     {
                         return AuthenticateResults.s_cancellationRequested;
                     }
 
-                    await Task.Delay(Options.RefreshCheckWait, Context.RequestAborted).ConfigureAwait(false);
-
-                    if (!Context.RequestAborted.IsCancellationRequested && !await _identityStore.IsRefreshing(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false))
+                    if (!await IdentityStore.IsRefreshing(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false))
                     {
-                        // Refresh is done, get the updated identity
-                        ClaimsIdentity? updatedIdentity = await _identityStore.GetIdentity(didClaim.Value, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-                        if (updatedIdentity == null)
+                        // The refresh has finished, so pick up the identity it stored.
+                        ClaimsIdentity? refreshedIdentity = await IdentityStore.GetIdentity(CurrentUserDid, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+
+                        if (refreshedIdentity is null)
                         {
                             return AuthenticateResults.s_identityStoreRefreshMissing;
                         }
-                        hydratedTicket = new AuthenticationTicket(new ClaimsPrincipal(updatedIdentity), ticket.Properties, ticket.AuthenticationScheme);
+
+                        hydratedTicket = new AuthenticationTicket(new ClaimsPrincipal(refreshedIdentity), ticket.Properties, ticket.AuthenticationScheme);
                         return AuthenticateResult.Success(hydratedTicket);
                     }
 
-                    refreshCheckCount++;
+                    try
+                    {
+                        await Task.Delay(Options.RefreshCheckWait, Context.RequestAborted).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return AuthenticateResults.s_cancellationRequested;
+                    }
                 }
 
                 if (Context.RequestAborted.IsCancellationRequested)

--- a/src/idunno.Bluesky.AspNet.Authentication/BlueskyExtensions.cs
+++ b/src/idunno.Bluesky.AspNet.Authentication/BlueskyExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using idunno.Bluesky.AspNet.Authentication;
@@ -115,7 +116,6 @@ public static class BlueskyExtensions
         Action<BlueskyAuthenticationOptions> configureOptions)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configureOptions);
 
         builder.Services.AddBlueskyAgentOptions();
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<BlueskyAgentOptions>, PostConfigureBlueskyAgentOptions>());
@@ -143,15 +143,44 @@ public static class BlueskyExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="BlueskyAgentFactory"/> to the service collection.
+    /// Adds a <see cref="BlueskyAgentFactory"/> to the service collection, for the authentication scheme specified by
+    /// <see cref="BlueskyAuthenticationDefaults.AuthenticationScheme"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add to.</param>
     /// <returns>The service collection</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddBlueskyAgentFactory(this IServiceCollection services)
+        => services.AddBlueskyAgentFactory(BlueskyAuthenticationDefaults.AuthenticationScheme);
+
+    /// <summary>
+    /// Adds a <see cref="BlueskyAgentFactory"/> to the service collection, for the specified authentication scheme.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="authenticationScheme">The name of the authentication scheme the factory should create agents for.</param>
+    /// <returns>The service collection</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> or <paramref name="authenticationScheme"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="authenticationScheme"/> is empty or white space.</exception>
+    /// <remarks>
+    /// <para>
+    ///   The factory takes the authentication scheme, and so the <see cref="BlueskyAuthenticationOptions"/> and <see cref="IIdentityStore"/> it should use,
+    ///   from the current user when the request has an authenticated Bluesky user. Specify <paramref name="authenticationScheme"/> if the application
+    ///   registered Bluesky authentication under a scheme name other than <see cref="BlueskyAuthenticationDefaults.AuthenticationScheme"/>, so that agents
+    ///   created for anonymous requests use the right options.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddBlueskyAgentFactory(this IServiceCollection services, string authenticationScheme)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(authenticationScheme);
+
         services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         services.AddOptions<BlueskyAgentOptions>();
-        services.AddSingleton<BlueskyAgentFactory>();
+        services.AddSingleton(provider => new BlueskyAgentFactory(
+            provider.GetRequiredService<IHttpContextAccessor>(),
+            provider.GetRequiredService<IOptionsMonitor<BlueskyAuthenticationOptions>>(),
+            provider.GetRequiredService<IOptionsMonitor<BlueskyAgentOptions>>(),
+            provider.GetRequiredService<ILoggerFactory>(),
+            authenticationScheme));
         services.AddScoped(provider => provider.GetRequiredService<BlueskyAgentFactory>().CreateAgent());
 
         return services;

--- a/src/idunno.Bluesky.AspNet.Authentication/ProfileClaimsTransformer.cs
+++ b/src/idunno.Bluesky.AspNet.Authentication/ProfileClaimsTransformer.cs
@@ -30,26 +30,36 @@ public sealed class ProfileClaimsTransformer: IClaimsTransformation
     /// <param name="loggerFactory">The <see cref="LoggerFactory"/> to create loggers from.</param>
     /// <param name="options">The <see cref="ProfileClaimsTransformerOptions"/> to configure the transformer.</param>
     /// <param name="blueskyAgentOptions">The <see cref="Bluesky.BlueskyAgentOptions"/> to use for the agent retrieving the profile.</param>
+    /// <param name="blueskyAuthenticationOptions">
+    ///   The <see cref="BlueskyAuthenticationOptions"/> used to locate the <see cref="IIdentityStore"/> any
+    ///   credentials updated whilst retrieving the profile should be saved to.
+    /// </param>
     /// <exception cref="ArgumentNullException">
-    ///   Thrown if <paramref name="options"/> is <see langword="null"/>.
+    ///   Thrown if <paramref name="options"/>, <paramref name="blueskyAgentOptions"/> or
+    ///   <paramref name="blueskyAuthenticationOptions"/> is <see langword="null"/>.
     /// </exception>
     public ProfileClaimsTransformer(
         ILoggerFactory loggerFactory,
         IOptionsMonitor<ProfileClaimsTransformerOptions> options,
-        IOptionsMonitor<BlueskyAgentOptions> blueskyAgentOptions)
+        IOptionsMonitor<BlueskyAgentOptions> blueskyAgentOptions,
+        IOptionsMonitor<BlueskyAuthenticationOptions> blueskyAuthenticationOptions)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(blueskyAgentOptions);
+        ArgumentNullException.ThrowIfNull(blueskyAuthenticationOptions);
 
         Options = options;
 
         loggerFactory ??= NullLoggerFactory.Instance;
 
         BlueskyAgentOptions = blueskyAgentOptions;
+        AuthenticationOptions = blueskyAuthenticationOptions;
         Logger = loggerFactory.CreateLogger(GetType().FullName!);
     }
 
     private IOptionsMonitor<BlueskyAgentOptions> BlueskyAgentOptions { get; }
+
+    private IOptionsMonitor<BlueskyAuthenticationOptions> AuthenticationOptions { get; }
 
     [NotNull]
     private IOptionsMonitor<ProfileClaimsTransformerOptions> Options { get; }
@@ -100,6 +110,16 @@ public sealed class ProfileClaimsTransformer: IClaimsTransformation
 
         using (BlueskyAgent agent = new(principal, BlueskyAgentOptions?.CurrentValue))
         {
+            // The agent makes authenticated calls, so its credentials can be updated underneath us, most commonly
+            // by a DPoP nonce rotation. Without this any updated credentials would be discarded when the agent is
+            // disposed and the next call would have to pay for another nonce rotation round trip.
+            IIdentityStore? identityStore = ResolveIdentityStore(principal.Identity.AuthenticationType);
+
+            if (identityStore is not null)
+            {
+                agent.CredentialsUpdatedAsync = identityStore.OnCredentialsUpdated;
+            }
+
             if (agent.IsAuthenticated)
             {
                 ProfileCacheEntry? cachedProfile = await Cache.GetCachedValue(agent.Did).ConfigureAwait(false);
@@ -129,6 +149,24 @@ public sealed class ProfileClaimsTransformer: IClaimsTransformation
         }
 
         return principal;
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="IIdentityStore"/> configured for the authentication scheme the principal was issued by.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///   <see cref="BlueskyAuthenticationOptions"/> are configured against the name of the authentication scheme they
+    ///   belong to, so the unnamed options instance is not necessarily the one the handler is using. The authentication
+    ///   type on a principal issued by the handler is the scheme name, so use that to get the right options instance.
+    /// </para>
+    /// </remarks>
+    /// <param name="authenticationScheme">The name of the authentication scheme the principal was issued by, if any.</param>
+    private IIdentityStore? ResolveIdentityStore(string? authenticationScheme)
+    {
+        authenticationScheme = string.IsNullOrEmpty(authenticationScheme) ? BlueskyAuthenticationDefaults.AuthenticationScheme : authenticationScheme;
+
+        return AuthenticationOptions.Get(authenticationScheme).IdentityStore;
     }
 
     private static ClaimsPrincipal SupplementClaimsPrincipal(ClaimsPrincipal principal, ProfileCacheEntry profile)

--- a/src/idunno.Bluesky.AspNet.Authentication/PublicAPI.Unshipped.txt
+++ b/src/idunno.Bluesky.AspNet.Authentication/PublicAPI.Unshipped.txt
@@ -205,7 +205,7 @@ idunno.Bluesky.AspNet.Authentication.ProfileCacheEntry.Pronouns.init -> void
 idunno.Bluesky.AspNet.Authentication.ProfileCacheEntry.Website.get -> System.Uri?
 idunno.Bluesky.AspNet.Authentication.ProfileCacheEntry.Website.init -> void
 idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformer
-idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformer.ProfileClaimsTransformer(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformerOptions!>! options, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.BlueskyAgentOptions!>! blueskyAgentOptions) -> void
+idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformer.ProfileClaimsTransformer(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformerOptions!>! options, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.BlueskyAgentOptions!>! blueskyAgentOptions, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.AspNet.Authentication.BlueskyAuthenticationOptions!>! blueskyAuthenticationOptions) -> void
 idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformer.TransformAsync(System.Security.Claims.ClaimsPrincipal! principal) -> System.Threading.Tasks.Task<System.Security.Claims.ClaimsPrincipal!>!
 idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformerOptions
 idunno.Bluesky.AspNet.Authentication.ProfileClaimsTransformerOptions.Cache.get -> idunno.Bluesky.AspNet.Authentication.IProfileCache?
@@ -292,3 +292,5 @@ virtual idunno.Bluesky.AspNet.Authentication.SignInResult.<Clone>$() -> idunno.B
 virtual idunno.Bluesky.AspNet.Authentication.SignInResult.EqualityContract.get -> System.Type!
 virtual idunno.Bluesky.AspNet.Authentication.SignInResult.Equals(idunno.Bluesky.AspNet.Authentication.SignInResult? other) -> bool
 virtual idunno.Bluesky.AspNet.Authentication.SignInResult.PrintMembers(System.Text.StringBuilder! builder) -> bool
+idunno.Bluesky.AspNet.Authentication.BlueskyAgentFactory.BlueskyAgentFactory(Microsoft.AspNetCore.Http.IHttpContextAccessor! contextAccessor, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.AspNet.Authentication.BlueskyAuthenticationOptions!>! authenticationOptionsMonitor, Microsoft.Extensions.Options.IOptionsMonitor<idunno.Bluesky.BlueskyAgentOptions!>! agentOptionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, string! authenticationScheme) -> void
+static Microsoft.Extensions.DependencyInjection.BlueskyExtensions.AddBlueskyAgentFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! authenticationScheme) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!


### PR DESCRIPTION
## Summary

Four fixes in `idunno.Bluesky.AspNet.Authentication`, found while re-reviewing `dev/aspnet` after #423.

The most serious is that a custom `IIdentityStore` configured in `AddBluesky(...)` was never actually used.

## The identity store was silently ignored

`BlueskyAuthenticationOptions` are configured against the name of the authentication scheme they belong to:

```
AddBluesky("Bluesky", o => o.IdentityStore = new DistributedCacheIdentityStore(...))
  └─> AddScheme<BlueskyAuthenticationOptions, ...>("Bluesky", null, configureOptions)
        └─> Services.Configure<BlueskyAuthenticationOptions>("Bluesky", configureOptions)
```

So the application's delegate only ever runs for the instance named `"Bluesky"`. But `BlueskyAuthenticationHandler`, `BlueskyAgentFactory` and `ProfileClaimsTransformer` all read the store from `IOptionsMonitor<BlueskyAuthenticationOptions>.CurrentValue`, which is `Get(Options.DefaultName)` — the *unnamed* instance, which the delegate never touched.

`PostConfigureBlueskyAuthenticationOptions` is registered unnamed, so it runs for every name and does `options.IdentityStore ??= new EphemeralIdentityStore(...)`, quietly filling the gap.

The result: an application which configured a `DistributedCacheIdentityStore` ran entirely on in-process memory. Every signed in user is lost when the process recycles, and credentials are not shared between instances of a scaled out deployment. The `ArgumentNullException.ThrowIfNull(...IdentityStore)` guards in the constructors could never fire, because post configuration always supplied a store.

It looks like it works on a single box because both store types keep their cache in a `static` field.

All three now resolve the store for the scheme they are running as:

* The handler reads `Options.IdentityStore`, which the base class resolves with `Get(Scheme.Name)`, instead of capturing `options.CurrentValue.IdentityStore` in its constructor. It throws an `InvalidOperationException` naming the scheme if no store is configured.
* `BlueskyAgentFactory` resolves per `CreateAgent()` call rather than snapshotting in its constructor, taking the scheme from `identity.AuthenticationType` — an identity issued by the handler carries the issuing scheme name as its authentication type.
* `ProfileClaimsTransformer` does the same. This needs an `IOptionsMonitor<BlueskyAuthenticationOptions>`, so its constructor takes one.

For an anonymous request there is no principal to take a scheme from, so `BlueskyAgentFactory` falls back to a configured scheme name, defaulting to `BlueskyAuthenticationDefaults.AuthenticationScheme`. `AddBlueskyAgentFactory(string authenticationScheme)` and a matching constructor overload are added for applications which register Bluesky authentication under a different scheme name.

## Requests could fail authentication while valid credentials sat in the store

The wait loop in `ReadCookieTicket` only checked the identity store *after* sleeping:

```csharp
while (... && await _identityStore.IsRefreshing(...))
{
    await Task.Delay(Options.RefreshCheckWait, Context.RequestAborted);
    if (!await _identityStore.IsRefreshing(...)) { /* success */ }
}
return AuthenticateResults.s_awaitTokenRefreshLoopExpired;
```

If the winning refresher called `EndRefresh` in the window between this request's initial `IsRefreshing` check and the `while` condition, the loop body never ran and the method returned failure — despite freshly refreshed credentials being in the store.

The loop now checks before waiting, so a just-completed refresh is picked up on the first iteration. A request whose wait is aborted now returns `s_cancellationRequested` rather than throwing a `TaskCanceledException` out of the handler, which is what the surrounding code already intended.

## Nonce rotations were discarded during claims transformation

`ProfileClaimsTransformer` creates a `BlueskyAgent` and makes an authenticated `GetProfile` call, but never set `CredentialsUpdatedAsync`. Any DPoP nonce rotation triggered by that call was discarded when the agent was disposed, so the next call paid for another rotation round trip. It now saves updated credentials to the identity store.

`BlueskyAgentFactory` had a related issue: it wired the callback using an identity it had already rejected as unusable.

## `AddBluesky()` and `AddBluesky(string)` always threw

Both pass `configureOptions: null!` to the terminal overload, which did `ArgumentNullException.ThrowIfNull(configureOptions)`, so neither could be used at all. Removed the guard — the `null!` idiom is deliberate in ASP.NET Core, and `AddCookie` does not guard it either. `AddScheme` accepts a null delegate. No signature change.

## API changes

Added:

* `BlueskyAgentFactory.BlueskyAgentFactory(IHttpContextAccessor, IOptionsMonitor<BlueskyAuthenticationOptions>, IOptionsMonitor<BlueskyAgentOptions>, ILoggerFactory, string)`
* `BlueskyExtensions.AddBlueskyAgentFactory(this IServiceCollection, string)`

Changed:

* `ProfileClaimsTransformer`'s constructor takes an additional `IOptionsMonitor<BlueskyAuthenticationOptions>`. It is resolved from DI, so applications using `AddProfileClaimsTransformer()` need no changes.

The existing four parameter `BlueskyAgentFactory` constructor and parameterless `AddBlueskyAgentFactory()` are unchanged and chain to the new overloads.

## Validation

`dotnet build` clean across net8.0, net9.0 and net10.0 with 0 warnings, and `dotnet test -f net10.0` at 1297 passed, 0 failed.

Worth noting that the package has no test coverage of its own, so these are verified by reading and by the build rather than by tests. Adding coverage for the handler's refresh paths would be worth doing separately.
